### PR TITLE
Moved redirect to envrc cache file into nix environment

### DIFF
--- a/bin/de
+++ b/bin/de
@@ -77,7 +77,7 @@ unset                 \
     TERM              \
     TERM_SESSION_ID;  \
 direnv dump           \
-"> .envrc.cache
+> .envrc.cache"
 
 identify_shell() {
     local shell="shell.nix"


### PR DESCRIPTION
With that, stderr is not going to be redirected to the envrc cache as well, potentially destroying the content